### PR TITLE
Draw from left to right

### DIFF
--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -55,9 +55,11 @@ const COLOR_MAPPINGS = {
 
 let getRealWork = rgbaOrder => {
     let order = [];
+	let j = 0;
     for (var i = 0; i < 2000000; i++) {
-        if (rgbaOrder[(i * 4) + 3] !== 0) {
-            order.push(i);
+		j = (i * 2000) % 2000000 + Math.floor((i * 2000) / 2000000);
+        if (rgbaOrder[(j * 4) + 3] !== 0) {
+            order.push(j);
         }
     }
     return order;

--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -188,8 +188,7 @@ async function attemptPlace() {
     }
 
     const percentComplete = 100 - Math.ceil(work.length * 100 / order.length);
-    const idx = Math.floor(Math.random() * work.length);
-    const i = work[idx];
+    const i = work[0];
     const x = i % 2000;
     const y = Math.floor(i / 2000);
     const hex = rgbaOrderToHex(i, rgbaOrder);

--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -55,9 +55,9 @@ const COLOR_MAPPINGS = {
 
 let getRealWork = rgbaOrder => {
     let order = [];
-	let j = 0;
+    let j = 0;
     for (var i = 0; i < 2000000; i++) {
-		j = (i * 2000) % 2000000 + Math.floor((i * 2000) / 2000000);
+        j = (i * 2000) % 2000000 + Math.floor((i * 2000) / 2000000);
         if (rgbaOrder[(j * 4) + 3] !== 0) {
             order.push(j);
         }


### PR DESCRIPTION
The randomization has been removed and now the script is drawing from left to right, top to bottom to first defend the original 42 logo and then build the new 42Network logo