### PR TITLE
Draw from left to right on headless bot

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -18,10 +18,8 @@ var currentOrders;
 
 var order = [];
 for (var i = 0; i < 2000000; i++) {
-    order.push(i);
+    order.push((i * 2000) % 2000000 + Math.floor((i * 2000) / 2000000));
 }
-order.sort(() => Math.random() - 0.5);
-
 
 const COLOR_MAPPINGS = {
 	'#BE0039': 1,


### PR DESCRIPTION
The randomization has been removed and now the script is drawing from left to right, top to bottom to first defend the original 42 logo and then build the new 42Network logo on headless bot